### PR TITLE
Support user-defined subdomains

### DIFF
--- a/aws/Readme.md
+++ b/aws/Readme.md
@@ -133,6 +133,7 @@ This will create a [default] set of credentials at ~/.aws/credentials
 | ssh_key_name | SSH Key Pair name from AWS Console. Required for debugging via SSH access when `enable_ssh_access` is set. | jitsi_key |
 | instance_type | Type of AWS instance for your Jitsi Meet server | m5.xlarge |
 | parent_subdomain | Subdomain under which Jitsi Meet will be hosted. | `meet.example.com` |
+| subdomain | (Optional) Subdomain under parent subdomain at which Jitsi Meet will be hosted | `dev`, `test`, `stage` |
 
 ##### Simulcast Streaming and Recording with Jibri (Optional)
 
@@ -170,7 +171,7 @@ All recordings whether streamed or recorded, will be available at `https://my-se
 Type 'yes' when prompted and hit enter.  
 This will create the following resources:
 1. An Amazon EC2 instance
-2. A Route53 DNS A Record with `<UUIDv4>.<parent_subdomain>` E.g. `511066ad.meet.example.com` pointing to the public IPv4 address of newly created Amazon EC2 instance.
+2. A Route53 DNS A Record with `<UUIDv4>.<parent_subdomain>` or `<subdomain>.<parent_subdomain>` E.g. `511066ad.meet.example.com` or `test.meet.example.com` pointing to the public IPv4 address of newly created Amazon EC2 instance.
 3. Security group that acts as a firewall for our EC2 instance. Allows traffic on `UDP 10000` (jitsi-videobridge) `TCP 80` (HTTP) `TCP 443` (HTTPS) and `UDP 53` (DNS). SSH access can optionally be enabled by setting `enable_ssh_access` variable to true.
 
 The command will print address of server host and an HTTPS URL for your Jitsi Meet server. E.g. `https://511066ad.meet.example.com`

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -31,6 +31,12 @@ admin_password = "somestrongpassword"
 #--------------------------------------------------------------
 parent_subdomain = "meet.mydomain.com"
 
+#---------------------------------------------------------------------------
+# (Optional) Subdomain under parent domain under which Jitsi will be hosted
+# Uses a random ID if this was not set
+# --------------------------------------------------------------------------
+# subdomain = "dev"
+
 #-------------------------------------------------------------
 # SSH access configuration for debugging
 #-------------------------------------------------------------

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -102,3 +102,9 @@ variable "rtmp_stream_urls" {
   type        = list
   default     = []
 }
+
+variable "subdomain" {
+  description = "(Optional) Subdomain under a parent domain to host this instance"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Enables support for user-defined subdomains E.g. `dev.meet.example.com` or `test.meet.example.com`

* Adds an optional variable `subdomain`
* Uses `subdomain` if provided, else falls back on random UUIDv4 ID for a subdomain